### PR TITLE
correctly determine the vis instance in all cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,9 @@ E.g., if it was used in a menu and the menu is red, the circle would be red.
     ### **WORK IN PROGRESS**
 -->
 ## Changelog
+### **WORK IN PROGRESS**
+* (foxriver76) correctly determine the vis instance in all cases
+
 ### 2.9.26 (2024-02-02)
 * (foxriver76) do not show empty icon category if jquery style selected for jquery button widgets
 * (foxriver76) added possibility to hide navigation after selection

--- a/main.js
+++ b/main.js
@@ -179,6 +179,8 @@ async function generateConfigPage(forceBuild, enabledList) {
 
     const configJs =
 `window.isLicenseError = ${isLicenseError};
+// inject the adapter instance
+window.visAdapterInstance = ${adapter.instance};
 // for back compatibility with vis.1 on cloud
 window.visConfig = {
     "widgetSets": ${JSON.stringify(widgetSets)}

--- a/src/package.json
+++ b/src/package.json
@@ -8,7 +8,7 @@
         "@devbookhq/splitter": "^1.4.2",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
-        "@iobroker/adapter-react-v5": "^4.9.4",
+        "@iobroker/adapter-react-v5": "^4.9.6",
         "@iobroker/type-detector": "^3.0.5",
         "@iobroker/types": "^5.0.17",
         "@iobroker/vis-2-widgets-react-dev": "^1.0.5",

--- a/src/src/Runtime.jsx
+++ b/src/src/Runtime.jsx
@@ -78,10 +78,10 @@ class Runtime extends GenericApp {
             window.socketUrl = `${window.location.protocol}//${window.location.hostname}${window.socketUrl}`;
         }
 
-        super(props, extendedProps);
-
         // for projects starting with numbers, adapter-react extracts wrong instance number, as we have no instance in url explicitly
-        this.instance = window.visAdapterInstance ?? this.instance;
+        extendedProps.instance = window.visAdapterInstance;
+
+        super(props, extendedProps);
 
         // do not control this state
         this.socket.setStateToIgnore('nothing_selected');

--- a/src/src/Runtime.jsx
+++ b/src/src/Runtime.jsx
@@ -80,6 +80,9 @@ class Runtime extends GenericApp {
 
         super(props, extendedProps);
 
+        // for projects starting with numbers, adapter-react extracts wrong instance number, as we have no instance in url explicitly
+        this.instance = window.visAdapterInstance ?? this.instance;
+
         // do not control this state
         this.socket.setStateToIgnore('nothing_selected');
 

--- a/src/src/global.d.ts
+++ b/src/src/global.d.ts
@@ -3,5 +3,7 @@ import type * as SpeechRecognition from 'dom-speech-recognition';
 declare global {
     interface Window {
         webkitSpeechRecognition?: SpeechRecognition;
+        /** The vis-2 adapter instance */
+        visAdapterInstance?: number;
     }
 }


### PR DESCRIPTION
- This fixes e.g. the problem that a project called `3_Test` will lead to the case, that adapter-react-v5 will determine the instance as `3`, because of https://github.com/ioBroker/adapter-react-v5/blob/bae98e05d9d0df4443b59bda6b7ac08f3135bf4f/src/GenericApp.js#L139 is using the first char in `window.location.search` if it is a number, because `vis-2` url is build like http://localhost:8082/vis-2/?3test#default but does not contain `instance=` in url
- While vis-2 is a singleton adapter, someone could add the single instance as a different than `0`, this is edgy but also caught here, else it would be enough to just pass `0`. Instead the backend is injecting the real instance number into the window object leading to an accurate instance detection
- closes #331 