### PR TITLE
TimePicker widget now saves the time instead of date by default, if y…

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,9 @@ E.g., if it was used in a menu and the menu is red, the circle would be red.
     ### **WORK IN PROGRESS**
 -->
 ## Changelog
+### **WORK IN PROGRESS**
+* (foxriver76) TimePicker widget now saves the time instead of date by default, if you want old behavior use checkbox `asDate`
+
 ### 2.9.36 (2024-02-27)
 * (foxriver76) fixed project-specific css not being applied
 

--- a/src/src/Vis/Widgets/JQui/JQuiInputDateTime.jsx
+++ b/src/src/Vis/Widgets/JQui/JQuiInputDateTime.jsx
@@ -19,6 +19,7 @@ import { withStyles } from '@mui/styles';
 
 import { TimePicker, LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import dayjs from 'dayjs';
 import 'dayjs/locale/de';
 import 'dayjs/locale/en';
 import 'dayjs/locale/ru';
@@ -91,6 +92,11 @@ class JQuiInputDateTime extends VisRxWidget {
                             type: 'checkbox',
                         },
                         {
+                            name: 'asDate',
+                            label: 'jqui_asDate',
+                            type: 'checkbox',
+                        },
+                        {
                             name: 'stepMinute',
                             label: 'jqui_stepMinute',
                             type: 'select',
@@ -125,19 +131,27 @@ class JQuiInputDateTime extends VisRxWidget {
     renderWidgetBody(props) {
         super.renderWidgetBody(props);
 
+        const val = this.state.values[`${this.state.rxData.oid}.val`];
+        const asDate = this.state.rxData.asDate;
+
         return <div
             className="vis-widget-body"
             onClick={this.state.rxData.html ? () => this.onClick() : undefined}
         >
             <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale={this.props.context.lang}>
                 <TimePicker
-                    value={this.state.values[`${this.state.rxData.oid}.val`] || ''}
+                    value={val && !asDate ? dayjs(val, 'HH:mm') : dayjs(val)}
                     ampm={this.state.rxData.ampm || false}
                     minutesStep={parseInt(this.state.rxData.stepMinute, 10) || 1}
                     label={this.state.rxData.widgetTitle || null}
                     formatDensity={this.state.rxData.wideFormat ? 'spacious' : 'dense'}
+                    format="HH:mm"
                     autoFocus={this.state.rxData.autoFocus || false}
-                    onChange={newValue => this.props.context.setValue(this.state.rxData.oid, newValue)}
+                    onChange={value => {
+                        value = !asDate ? value.format('HH:mm') : value.toDate();
+
+                        this.props.context.setValue(this.state.rxData.oid, value);
+                    }}
                     slotProps={{
                         textField: {
                             variant: this.state.rxData.variant || 'standard',

--- a/src/src/Vis/Widgets/JQui/JQuiInputDateTime.tsx
+++ b/src/src/Vis/Widgets/JQui/JQuiInputDateTime.tsx
@@ -14,7 +14,6 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import { withStyles } from '@mui/styles';
 
 import { TimePicker, LocalizationProvider } from '@mui/x-date-pickers';
@@ -33,6 +32,8 @@ import 'dayjs/locale/pt';
 import 'dayjs/locale/nl';
 
 // eslint-disable-next-line import/no-cycle
+import { GetRxDataFromWidget, RxRenderWidgetProps } from '@/types';
+import type { TextFieldVariants } from '@mui/material';
 import VisRxWidget from '../../visRxWidget';
 
 const styles = {
@@ -44,7 +45,9 @@ const styles = {
     },
 };
 
-class JQuiInputDateTime extends VisRxWidget {
+type RxData = GetRxDataFromWidget<typeof JQuiInputDateTime>
+
+class JQuiInputDateTime extends VisRxWidget<RxData> {
     static getWidgetInfo() {
         return {
             id: 'tplJquiInputDatetime',
@@ -120,7 +123,7 @@ class JQuiInputDateTime extends VisRxWidget {
                 width: 250,
                 height: 56,
             },
-        };
+        } as const;
     }
 
     // eslint-disable-next-line class-methods-use-this
@@ -128,7 +131,7 @@ class JQuiInputDateTime extends VisRxWidget {
         return JQuiInputDateTime.getWidgetInfo();
     }
 
-    renderWidgetBody(props) {
+    renderWidgetBody(props: RxRenderWidgetProps) {
         super.renderWidgetBody(props);
 
         const val = this.state.values[`${this.state.rxData.oid}.val`];
@@ -136,7 +139,6 @@ class JQuiInputDateTime extends VisRxWidget {
 
         return <div
             className="vis-widget-body"
-            onClick={this.state.rxData.html ? () => this.onClick() : undefined}
         >
             <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale={this.props.context.lang}>
                 <TimePicker
@@ -144,18 +146,21 @@ class JQuiInputDateTime extends VisRxWidget {
                     ampm={this.state.rxData.ampm || false}
                     minutesStep={parseInt(this.state.rxData.stepMinute, 10) || 1}
                     label={this.state.rxData.widgetTitle || null}
-                    formatDensity={this.state.rxData.wideFormat ? 'spacious' : 'dense'}
+                    formatDensity="dense"
                     format="HH:mm"
                     autoFocus={this.state.rxData.autoFocus || false}
                     onChange={value => {
-                        value = !asDate ? value.format('HH:mm') : value.toDate();
+                        if (!value) {
+                            return;
+                        }
 
-                        this.props.context.setValue(this.state.rxData.oid, value);
+                        const res = !asDate ? value.format('HH:mm') : value.toDate();
+
+                        this.props.context.setValue(this.state.rxData.oid, res);
                     }}
                     slotProps={{
                         textField: {
-                            variant: this.state.rxData.variant || 'standard',
-                            size: this.state.rxData.small ? 'small' : undefined,
+                            variant: this.state.rxData.variant as TextFieldVariants || 'standard',
                             style: {
                                 width: '100%',
                                 height: '100%',
@@ -171,13 +176,5 @@ class JQuiInputDateTime extends VisRxWidget {
         </div>;
     }
 }
-
-JQuiInputDateTime.propTypes = {
-    id: PropTypes.string.isRequired,
-    context: PropTypes.object.isRequired,
-    view: PropTypes.string.isRequired,
-    editMode: PropTypes.bool.isRequired,
-    tpl: PropTypes.string.isRequired,
-};
 
 export default withStyles(styles)(JQuiInputDateTime);

--- a/src/src/Vis/Widgets/JQui/JQuiInputDateTime.tsx
+++ b/src/src/Vis/Widgets/JQui/JQuiInputDateTime.tsx
@@ -154,7 +154,7 @@ class JQuiInputDateTime extends VisRxWidget<RxData> {
                             return;
                         }
 
-                        const res = !asDate ? value.format('HH:mm') : value.toDate();
+                        const res = !asDate ? value.format('HH:mm') : value.second(0).millisecond(0).toDate();
 
                         this.props.context.setValue(this.state.rxData.oid, res);
                     }}

--- a/src/src/Vis/visBaseWidget.tsx
+++ b/src/src/Vis/visBaseWidget.tsx
@@ -58,6 +58,7 @@ interface Context {
     formatUtils: any;
     socket: Connection;
     systemConfig: Record<string, any>;
+    setValue: (id: string, value: unknown) => void;
 }
 
 export interface VisBaseWidgetProps {
@@ -92,6 +93,8 @@ export interface VisBaseWidgetProps {
     mouseDownOnView: (...props: any[]) => void;
     refParent: React.RefObject<any>;
     customSettings: any;
+    classes: any;
+    socket: Connection;
 }
 
 type Resize = 'left' | 'right' | 'top' | 'bottom' | 'bottom-left' | 'bottom-right' | 'top-left' | 'top-right' | boolean

--- a/src/src/i18n/de.json
+++ b/src/src/i18n/de.json
@@ -536,6 +536,7 @@
   "jqui_Select file": "Bild auswählen",
   "jqui_active_color": "Aktive Farbe",
   "jqui_ampm": "Vormittags/Nachmittags",
+  "jqui_asDate": "Als Datum",
   "jqui_as_string": "Als String",
   "jqui_auto": "Auto",
   "jqui_binary_control": "Binäre Steuerung",

--- a/src/src/i18n/en.json
+++ b/src/src/i18n/en.json
@@ -536,6 +536,7 @@
   "jqui_Select file": "Select image",
   "jqui_active_color": "Active color",
   "jqui_ampm": "Am/Pm",
+  "jqui_asDate": "As date",
   "jqui_as_string": "As string",
   "jqui_auto": "auto",
   "jqui_binary_control": "Binary control",

--- a/src/src/i18n/es.json
+++ b/src/src/i18n/es.json
@@ -536,6 +536,7 @@
   "jqui_Select file": "Seleccionar imagen",
   "jqui_active_color": "color activo",
   "jqui_ampm": "Am PM",
+  "jqui_asDate": "como fecha",
   "jqui_as_string": "Como cuerda",
   "jqui_auto": "auto",
   "jqui_binary_control": "control binario",

--- a/src/src/i18n/fr.json
+++ b/src/src/i18n/fr.json
@@ -536,6 +536,7 @@
   "jqui_Select file": "Sélectionner une image",
   "jqui_active_color": "Couleur active",
   "jqui_ampm": "Matin après-midi",
+  "jqui_asDate": "Comme date",
   "jqui_as_string": "En tant que chaîne",
   "jqui_auto": "auto",
   "jqui_binary_control": "Contrôle binaire",

--- a/src/src/i18n/it.json
+++ b/src/src/i18n/it.json
@@ -536,6 +536,7 @@
   "jqui_Select file": "Seleziona l'immagine",
   "jqui_active_color": "Colore attivo",
   "jqui_ampm": "Am PM",
+  "jqui_asDate": "Come data",
   "jqui_as_string": "Come stringa",
   "jqui_auto": "auto",
   "jqui_binary_control": "Controllo binario",

--- a/src/src/i18n/nl.json
+++ b/src/src/i18n/nl.json
@@ -536,6 +536,7 @@
   "jqui_Select file": "Selecteer afbeelding",
   "jqui_active_color": "Actieve kleur",
   "jqui_ampm": "AM PM",
+  "jqui_asDate": "Als datum",
   "jqui_as_string": "Als touwtje",
   "jqui_auto": "auto",
   "jqui_binary_control": "Binaire controle",

--- a/src/src/i18n/pl.json
+++ b/src/src/i18n/pl.json
@@ -536,6 +536,7 @@
   "jqui_Select file": "Wybierz obraz",
   "jqui_active_color": "Aktywny kolor",
   "jqui_ampm": "Jestem/Po południu",
+  "jqui_asDate": "Jako data",
   "jqui_as_string": "Jako ciąg",
   "jqui_auto": "automatyczny",
   "jqui_binary_control": "Sterowanie binarne",

--- a/src/src/i18n/pt.json
+++ b/src/src/i18n/pt.json
@@ -536,6 +536,7 @@
   "jqui_Select file": "Selecione a imagem",
   "jqui_active_color": "Cor ativa",
   "jqui_ampm": "Manhã tarde",
+  "jqui_asDate": "Como data",
   "jqui_as_string": "Como corda",
   "jqui_auto": "auto",
   "jqui_binary_control": "Controle binário",

--- a/src/src/i18n/ru.json
+++ b/src/src/i18n/ru.json
@@ -536,6 +536,7 @@
   "jqui_Select file": "Выберите изображение",
   "jqui_active_color": "Активный цвет",
   "jqui_ampm": "До полудня после полудня",
+  "jqui_asDate": "Как дата",
   "jqui_as_string": "Как строка",
   "jqui_auto": "авто",
   "jqui_binary_control": "Двоичное управление",

--- a/src/src/i18n/uk.json
+++ b/src/src/i18n/uk.json
@@ -536,6 +536,7 @@
   "jqui_Select file": "Виберіть зображення",
   "jqui_active_color": "Активний колір",
   "jqui_ampm": "Дообіду, після обіду",
+  "jqui_asDate": "Як дата",
   "jqui_as_string": "Як рядок",
   "jqui_auto": "авто",
   "jqui_binary_control": "Двійковий контроль",

--- a/src/src/i18n/zh-cn.json
+++ b/src/src/i18n/zh-cn.json
@@ -536,6 +536,7 @@
   "jqui_Select file": "选择图片",
   "jqui_active_color": "活性颜色",
   "jqui_ampm": "上午下午",
+  "jqui_asDate": "截至日期",
   "jqui_as_string": "作为字符串",
   "jqui_auto": "汽车",
   "jqui_binary_control": "二元控制",


### PR DESCRIPTION
…ou want old behavior use checkbox 'asDate'

- closes #387, closes #183