### PR TITLE
Change number of possible signals to six

### DIFF
--- a/packages/iobroker.vis-2/src-vis/src/Attributes/Widget/index.tsx
+++ b/packages/iobroker.vis-2/src-vis/src/Attributes/Widget/index.tsx
@@ -389,7 +389,7 @@ class Widget extends Component<WidgetProps, WidgetState> {
                     label: 'signals-count',
                     type: 'select',
                     // noTranslation: true,
-                    options: ['0', '1', '2', '3'],
+                    options: ['0', '1', '2', '3', '4', '5', '6'],
                     default: '0',
                     immediateChange: true,
                 },


### PR DESCRIPTION
Is it possible to allow more than 3 active signals? Eg. 6 would be nice (like a dice). This commit is not testet, it's just wishfull thinking. I did not check for implications.