### PR TITLE
On adding attribute group use default values instead of null

### DIFF
--- a/packages/iobroker.vis-2/src-vis/src/Attributes/Widget/index.tsx
+++ b/packages/iobroker.vis-2/src-vis/src/Attributes/Widget/index.tsx
@@ -1371,7 +1371,7 @@ class Widget extends Component<WidgetProps, WidgetState> {
 
                 lastGroup.fields.forEach((_attr, i) => {
                     const name = lastGroup.fields[i].name.replace(/\d?\d+$/, newIndex.toString());
-                    widgetData[name] = null;
+                    widgetData[name] = _attr.default ?? null;
                 });
 
                 // enable group-used flag


### PR DESCRIPTION
When adding new attribute group in vis edit, it should use the default values for each attribute field instead of null. Otherwise particular behaviour of widgets does not work.

Related issue: https://github.com/ioBroker/ioBroker.vis-2/issues/435

Issues where this behaviour was found:
https://github.com/inventwo/ioBroker.vis-2-widgets-inventwo/issues/21
https://github.com/inventwo/ioBroker.vis-2-widgets-inventwo/issues/23
