### PR TITLE
fix: correct date formatting in export filename

### DIFF
--- a/packages/iobroker.vis-2/src-vis/src/Toolbar/ProjectsManager/index.tsx
+++ b/packages/iobroker.vis-2/src-vis/src/Toolbar/ProjectsManager/index.tsx
@@ -141,18 +141,9 @@ const ProjectsManager: React.FC<ProjectsManagerProps> = props => {
                     window.alert(data.error);
                 } else {
                     const d = new Date();
-                    let date = d.getFullYear().toString();
-                    let m = d.getMonth() + 1;
-                    let mString = m.toString();
-                    if (m < 10) {
-                        mString = `0${m}`;
-                    }
-                    date += `-${mString}`;
-                    m = d.getDate();
-                    if (m < 10) {
-                        mString = `0${m}`;
-                    }
-                    date += `-${mString}-`;
+                    const month = String(d.getMonth() + 1).padStart(2, '0');
+                    const day = String(d.getDate()).padStart(2, '0');
+                    const date = `${d.getFullYear()}-${month}-${day}-`;
                     setWorking(false);
                     (window.$ as any)('body').append(
                         `<a id="zip_download" href="data: application/zip;base64,${data.data}" download="${date}${projectName}.zip"></a>`,


### PR DESCRIPTION
Replace verbose manual date formatting with padStart() to fix a bug where the day value was not updated in mString when day >= 10, causing the month value to be repeated in the export filename.

Before: 2026-05-05-projectname.zip (wrong)
After:  2026-05-26-projectname.zip (correct)

[#601](https://github.com/ioBroker/ioBroker.vis-2/issues/601)