### PR TITLE
fix: respect visibility condition when the state value is null

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,9 @@ npm run start
     ### **WORK IN PROGRESS**
 -->
 ## Changelog
+### **WORK IN PROGRESS**
+* (@typhosj) Fixed the visibility condition if the state value is `null`
+
 ### 2.14.3 (2026-06-09)
 * (@GermanBluefox) Applied the user-defined style to tplValueInput
 

--- a/packages/iobroker.vis-2/src-vis/src/Vis/visBaseWidget.tsx
+++ b/packages/iobroker.vis-2/src-vis/src/Vis/visBaseWidget.tsx
@@ -1263,18 +1263,21 @@ class VisBaseWidget<TState extends Partial<VisBaseWidgetState> = VisBaseWidgetSt
             }
 
             let val = states[`${oid}.val`];
+            let value = widgetData['visibility-val'];
 
             if (val === undefined || val === null) {
-                return condition === 'not exist';
+                // the user compares explicitly against null => use the "null" placeholder in the comparison below
+                if (value !== 'null') {
+                    return condition === 'not exist';
+                }
+                val = 'null';
             }
-
-            let value = widgetData['visibility-val'];
 
             if (!condition || value === undefined || value === null) {
                 return condition === 'not exist';
             }
 
-            if (val === 'null' && condition !== 'exist' && condition !== 'not exist') {
+            if (val === 'null' && condition !== 'exist' && condition !== 'not exist' && value !== 'null') {
                 return false;
             }
 

--- a/packages/iobroker.vis-2/src-vis/src/Vis/visEngine.tsx
+++ b/packages/iobroker.vis-2/src-vis/src/Vis/visEngine.tsx
@@ -1105,17 +1105,21 @@ export default class VisEngine extends React.Component<VisEngineProps, VisEngine
                     if (val === undefined || val === null) {
                         val = this.canStates.attr(`${oid}.val`);
                     }
-                    if (val === undefined || val === null) {
-                        return condition === 'not exist';
-                    }
-
                     let value = widgetData['visibility-val'];
+
+                    if (val === undefined || val === null) {
+                        // the user compares explicitly against null => use the "null" placeholder in the comparison below
+                        if (value !== 'null') {
+                            return condition === 'not exist';
+                        }
+                        val = 'null';
+                    }
 
                     if (!condition || value === undefined || value === null) {
                         return condition === 'not exist';
                     }
 
-                    if (val === 'null' && condition !== 'exist' && condition !== 'not exist') {
+                    if (val === 'null' && condition !== 'exist' && condition !== 'not exist' && value !== 'null') {
                         return false;
                     }
 


### PR DESCRIPTION
Fixes #612

### Problem

The visibility check returns early as soon as the state value is `null`/`undefined`:

```ts
if (val === undefined || val === null) {
    return condition === 'not exist';
}
```

So a visibility condition like `myState != null` is never evaluated and the widget stays visible, even though the user explicitly configured `null` as the comparison value. The same code exists twice: `VisBaseWidget.isWidgetHidden()` (React widgets) and the `isWidgetHidden` callback in `visEngine` (can widgets), so both engines are affected.

### Change

If — and only if — the configured comparison value is the literal string `null`, the state value is passed into the comparison as the `null` placeholder the switch below already understands, instead of returning early. The guard that skips comparison conditions for that placeholder got the same exception.

Every other comparison value keeps the previous behaviour, so existing projects relying on "widget stays visible while the value is unknown" are not affected.

### Test

1. Create a state with the value `null`
2. Add a widget with the visibility condition `<state> != null`
3. The widget is hidden while the value is `null`, and shown again as soon as a value arrives

`== null`, `exist` and `not exist` behave accordingly.

The `NaN` part of the issue title already works (`NaN` is compared as a string), no change needed there.
