### PR TITLE
fix: correct the CSS regressions the MUI variables and CssBaseline brought (#661)

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,11 @@ npm run start
     ### **WORK IN PROGRESS**
 -->
 ## Changelog
+### **WORK IN PROGRESS**
+* (@typhosj) An `iFrame` or `echarts` widget is transparent again in the dark mode. The CSS variables put `color-scheme: dark` on `:root`, and a browser paints an opaque background behind an iframe whose document does not carry the same scheme (#661)
+* (@typhosj) The content of a widget that is wrapped in a card is not cut off anymore. `CssBaseline` switched the whole document to `border-box`, while the widgets - the built-in ones and those of other adapters alike - are laid out for the default `content-box` (#661)
+* (@typhosj) The text of a `Fab` button is readable again in the dark mode. MUI writes `text.primary` into it as soon as the CSS variables are generated, which is white, although the background of the button stays light grey in both themes (#661)
+
 ### 2.15.4 (2026-08-19)
 * (@GermanBluefox) Fixed the loading of the vis-2-widgets-material widget set on the cloud: it is built as an ES module and was still forced to be loaded as a global script, which ended in `remoteEntryExports is undefined`
 * (@GermanBluefox) The bundler type of the widget sets is only patched on the real cloud domains now. Local installations reachable under a name like `iobroker.local` or `iobroker.fritz.box` were treated as cloud before and could not load their widget sets

--- a/packages/iobroker.vis-2/src-vis/src/theme.tsx
+++ b/packages/iobroker.vis-2/src-vis/src/theme.tsx
@@ -17,7 +17,32 @@ export default function createTheme(
     const success = '#73b6a8';
     let theme: VisTheme = Theme(themeName, overrides) as VisTheme;
     if (cssVariables) {
-        theme = muiCreateTheme({ ...theme, cssVariables: true }) as VisTheme;
+        theme = muiCreateTheme({
+            ...theme,
+            // `color-scheme: dark` on `:root` makes the browser paint an opaque background behind an iframe
+            // whose document does not carry the same scheme, so an `iFrame` or `echarts` widget lost its
+            // transparency in the dark mode
+            cssVariables: { disableCssColorScheme: true },
+            components: {
+                ...theme.components,
+                MuiCssBaseline: {
+                    styleOverrides: {
+                        // `CssBaseline` switches the whole document to `border-box`. The widgets - the built-in
+                        // ones and those of other adapters alike - are laid out for the default `content-box`
+                        // and get their content cut off by it
+                        '*, *::before, *::after': { boxSizing: 'initial' },
+                    },
+                },
+                MuiFab: {
+                    styleOverrides: {
+                        // MUI writes `var(--mui-palette-text-primary)` as soon as the CSS variables are
+                        // generated - white in the dark mode - while the background stays `grey[300]`.
+                        // Without the variables it is the contrast text of that background.
+                        root: { '&.MuiFab-default': { color: 'rgba(0, 0, 0, 0.87)' } },
+                    },
+                },
+            },
+        }) as VisTheme;
     }
     theme.palette.text.danger = {
         color: danger,


### PR DESCRIPTION
Fixes #661.

Three findings of the issue, two causes, both in vis-2 itself - the widget sets of the other adapters are only where the effect shows up.

### 1. `:root { color-scheme: dark }` (since 2.15.0, `cssVariables: true`)

The generated CSS variables carry the color scheme: `prepareCssVars()` writes `colorScheme` into the same `:root` block as the `--mui-palette-*` variables unless `disableCssColorScheme` is set. A browser paints an opaque background behind an iframe whose document does not carry the same scheme, so an `iFrame` or `echarts` widget lost its transparency in the dark mode.

### 2. `box-sizing: border-box` for the whole document (since 2.15.4, `<CssBaseline />`)

`CssBaseline` sets `html { box-sizing: border-box }` plus `*, *::before, *::after { box-sizing: inherit }`. There was no `CssBaseline` before 2.15.4, so everything was laid out for the default `content-box` - `wrapContent()` sizes the card content as `calc(100% - 32px)` and adds the 32 px of padding itself. With `border-box` the padding is subtracted a second time and the content is cut off. That hits every widget set that is built for the old behaviour, not only `vis-2-widgets-material`, so the reset is taken back instead of changing the widgets.

### 3. The label of a default `Fab` (since 2.15.0, `cssVariables: true`)

```js
// @mui/material/Fab/Fab.js
color: theme.vars ? theme.vars.palette.text.primary : theme.palette.getContrastText?.(theme.palette.grey[300]),
backgroundColor: (theme.vars || theme).palette.grey[300],
```

The background stays `grey[300]` in both themes, but with the variables the label becomes `text.primary` - white in the dark mode. Without them it is the contrast text of that background. MUI has no `palette.Fab` entry that would carry the difference, unlike `Alert`, `AppBar`, `Chip` or `FilledInput`, so the theme sets the color back.

### Verification

Measured in Chrome against the dark theme, before and after:

| | 2.15.4 | with this PR |
| --- | --- | --- |
| `getComputedStyle(document.documentElement).colorScheme` | `dark` | `normal` |
| `getComputedStyle(document.body).boxSizing` | `border-box` | `content-box` |
| `.MuiFab-default` color on `rgb(224, 224, 224)` | `rgb(255, 255, 255)` | `rgba(0, 0, 0, 0.87)` |
| content box of a 200 px card wrapped by `wrapContent()` | 136 px | 168 px |

`theme.components` of `adapter-react-v5` (`MuiAppBar`, `MuiButton`, `MuiLink`, `MuiPaper`) are kept, none of them is one of the two overridden components.
