### PR TITLE
fix: load the widget set language file from the path it is served from

### DIFF
--- a/packages/iobroker.vis-2/src-vis/src/Vis/visLoadWidgets.tsx
+++ b/packages/iobroker.vis-2/src-vis/src/Vis/visLoadWidgets.tsx
@@ -21,6 +21,13 @@ import { registerRemotes, loadRemote, init } from '@module-federation/runtime';
 export type WidgetSetName = Branded<string, 'WidgetSetName'>;
 export type PromiseName = `_promise_${WidgetSetName}`;
 
+/**
+ * Prefix a widget set's url gets for `registerRemotes`, which resolves it against the application
+ * root. `fetch` does not: it resolves against the current document, which already sits under
+ * `/vis-2/`, so anything reading the url back has to strip this first.
+ */
+const VIS2_URL_PREFIX = './vis-2/';
+
 export interface VisRxWidgetWithInfo<
     TRxData extends Record<string, any>,
     TState extends Partial<VisRxWidgetState> = VisRxWidgetState,
@@ -211,7 +218,7 @@ function getRemoteWidgets(
                         }
 
                         if (!visWidgetsCollection.url?.startsWith('http')) {
-                            visWidgetsCollection.url = `./vis-2/widgets/${visWidgetsCollection.url}`;
+                            visWidgetsCollection.url = `${VIS2_URL_PREFIX}widgets/${visWidgetsCollection.url}`;
                         }
 
                         registerRemotes(
@@ -233,13 +240,20 @@ function getRemoteWidgets(
                                     // 1. Load language file ------------------
                                     // instance.common.visWidgets.i18n is deprecated
                                     if (collection.url && collection.i18n === true) {
-                                        // load i18n from files
-                                        const pos = collection.url.lastIndexOf('/');
+                                        // load i18n from files.
+                                        // `collection.url` carries VIS2_URL_PREFIX for registerRemotes, which resolves
+                                        // it against the application root. `fetch` resolves against the current
+                                        // document instead, and that already sits under /vis-2/ - keeping the prefix
+                                        // asked for /vis-2/vis-2/widgets/<set>/i18n/<lang>.json and always answered 404.
+                                        const baseUrl = collection.url.startsWith(VIS2_URL_PREFIX)
+                                            ? collection.url.substring(VIS2_URL_PREFIX.length)
+                                            : collection.url;
+                                        const pos = baseUrl.lastIndexOf('/');
                                         let i18nURL: string;
                                         if (pos !== -1) {
-                                            i18nURL = collection.url.substring(0, pos);
+                                            i18nURL = baseUrl.substring(0, pos);
                                         } else {
-                                            i18nURL = collection.url;
+                                            i18nURL = baseUrl;
                                         }
                                         const lang = I18n.getLanguage();
 


### PR DESCRIPTION
Fixes #664.

## Problem

A widget set with `common.visWidgets.<set>.i18n: true` never receives its translations. The
collection url is prefixed for `registerRemotes`, which resolves it against the application root:

```ts
visWidgetsCollection.url = `./vis-2/widgets/${visWidgetsCollection.url}`;
```

The `i18n === true` branch then derives the language-file url from that same, already prefixed
value and passes it to a plain `fetch()`. `fetch` resolves against the current document, and the
document already sits under `/vis-2/`, so the request goes to

```
/vis-2/vis-2/widgets/<set>/i18n/<lang>.json   404
```

in the editor as well as in the runtime. The `catch` only logs, so the set stays untranslated and
nothing else reports a problem.

The visible symptom is a partial failure rather than an obvious one. The attributes panel builds a
group header two ways: with an explicit `label` it goes through `I18n.t()`, which has no
dictionary and returns the key, and without one through `window.vis._()`, which still resolves.
One panel then reads `"Allgemein", "group_chartLayout", "group_barLayout", "group_yAxisLayout",
"group_tooltipLayout"`. Nothing about that points at i18n loading.

## Change

The prefix becomes a named constant, and the i18n branch strips it before deriving the path, so
the request goes to `widgets/<set>/i18n/<lang>.json` — the same place the bundle it belongs to is
served from. A `http://…` url is left alone, as before. Nothing else reads the url back, so the
prefixed value keeps working for `registerRemotes`.

## Verification

Both derivations run side by side inside the running editor, so the fetch resolves against the
real document base:

```json
{
 "document": "http://<host>:8082/vis-2/edit.html?<project>",
 "old":   { "path": "./vis-2/widgets/vis2-materialdesign/i18n/de.json",
            "resolved": "http://<host>:8082/vis-2/vis-2/widgets/vis2-materialdesign/i18n/de.json",
            "status": 404 },
 "fixed": { "path": "widgets/vis2-materialdesign/i18n/de.json",
            "resolved": "http://<host>:8082/vis-2/widgets/vis2-materialdesign/i18n/de.json",
            "status": 200 }
}
```

`tsc --noEmit` and `eslint` on `src-vis` are clean.

Found while porting `ioBroker.vis2-materialdesign` to `i18n: true`; that widget set had to go back
to `i18n: "component"` and its ~515 kB all-languages chunk until this lands.
