### PR TITLE
fix: point licenseInformation.link at the license editions instead of the source license

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ npm run start
 -->
 ## Changelog
 ### **WORK IN PROGRESS**
+* (@typhosj) `licenseInformation.link` points at the license editions now. For a non-free license that link is meant to name validity, shop and seller, which the source license file does not
 * (@typhosj) A timestamp that arrives as a string is shown as a date again instead of `NaN:NaN:NaN`, and a value that cannot be parsed at all is shown as it is
 * (@typhosj) A widget that leads to the view that is shown gets the CSS class `vis-nav-active`, so the current entry of a self-built navigation can be highlighted. The jQui buttons mark themselves by the active view now instead of the address of the browser, which they never noticed changing
 * (@typhosj) The project setting `States Debounce Time` is applied again: the commands for one object ID are collected during that period. It had no effect at all, as the value was never read from the project

--- a/packages/iobroker.vis-2/io-package.json
+++ b/packages/iobroker.vis-2/io-package.json
@@ -230,7 +230,7 @@
     ],
     "licenseInformation": {
       "type": "commercial",
-      "link": "https://raw.githubusercontent.com/ioBroker/ioBroker.vis-2/master/LICENSE",
+      "link": "https://iobroker.net/www/pricing",
       "license": "CC-BY-NC-4.0"
     },
     "stopBeforeUpdate": true


### PR DESCRIPTION
### Summary

`common.licenseInformation.link` pointed at the `LICENSE` file of this repository. @mcm1957 raised this in #649:

> The url link at licenseInformation is wrong. It should point to a file / url describing the commercial aspects of the license an(costs, place to buy, ...) and should NOT point to LICENSE at repository

The link now points at https://iobroker.net/www/pricing, the page the README already names in "License requirements" - it lists the Community, Private-use Offline and Commercial editions. The `LICENSE` file stays what it is: the CC BY-NC text the source code is published under, which is a different thing from the license a user needs to run the adapter.

### Why the checker cares

`@iobroker/repochecker` (`lib/M1000_IOPackageJson.js`) raises **W1137** for a link that resolves to the README or the LICENSE file of the adapter's own repository. It matches both `github.com/<owner>/<repo>/blob/...` and `raw.githubusercontent.com/<owner>/<repo>/...` against the file names `readme.md`, `license` and `license.md` - the old value hit all of it. **W1071** requires the link at all for a non-free adapter (`type: commercial`), and **W1138** only asks that it answers with content, which the pricing page does.

### Testing

- No code touched, `packages/iobroker.vis-2/io-package.json` only
- `https://iobroker.net/www/pricing` answers 200
